### PR TITLE
Pass user and Flatpak host font directories to the font generator on Linux, bump to 0.17.4-alpha (#29)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
         type: boolean
   push:
     branches:
-      - feat/37-linux-dmabuf-render
+      - feat/39-linux-user-font-dirs
     tags:
       - "v*"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -390,6 +390,33 @@ fn main() {
         .expect("error running Euro-Office Lite");
 }
 
+// x2t does not use fontconfig: it scans a fixed list of directories
+// (/usr/share/fonts, /usr/share/X11/fonts, /usr/local/share/fonts and a couple more),
+// so fonts installed per user or exposed by the Flatpak host mounts are invisible to
+// the editor even though fc-list finds them (issue #29). Passing them explicitly is
+// safe: x2t deduplicates directories it already scans.
+#[cfg(target_os = "linux")]
+fn extra_font_dirs() -> Vec<std::path::PathBuf> {
+    let mut dirs: Vec<std::path::PathBuf> = vec![
+        // Flatpak host font mounts
+        std::path::PathBuf::from("/run/host/fonts"),
+        std::path::PathBuf::from("/run/host/local-fonts"),
+        std::path::PathBuf::from("/run/host/user-fonts"),
+    ];
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = std::path::PathBuf::from(home);
+        dirs.push(home.join(".local/share/fonts"));
+        dirs.push(home.join(".fonts"));
+    }
+    dirs.retain(|dir| dir.is_dir());
+    dirs
+}
+
+#[cfg(not(target_os = "linux"))]
+fn extra_font_dirs() -> Vec<std::path::PathBuf> {
+    Vec::new()
+}
+
 fn run_font_generation(temp_dir: &std::path::Path, binaries_dir: &std::path::Path) {
     let marker = temp_dir.join(".fonts_generated");
 
@@ -448,6 +475,10 @@ fn run_font_generation(temp_dir: &std::path::Path, binaries_dir: &std::path::Pat
         .arg("-create-allfonts")
         .arg(&fontdata_str)
         .arg(&fonts_str);
+    for dir in extra_font_dirs() {
+        log_startup(temp_dir, &format!("Extra font directory: {}", dir.display()));
+        cmd.arg(dir);
+    }
     #[cfg(target_os = "linux")]
     cmd.env("LD_LIBRARY_PATH", binaries_dir);
     match cmd.output() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "productName": "Euro-Office-Lite",
   "mainBinaryName": "euro-office-lite",
-  "version": "0.17.3-alpha",
+  "version": "0.17.4-alpha",
   "identifier": "org.euro-office.lite",
   "build": {
     "frontendDist": "../src-dist",

--- a/src/index.html
+++ b/src/index.html
@@ -79,7 +79,7 @@
     </div>
     <div>
       <h1>Euro-Office Lite</h1>
-      <p class="version">v0.17.3-alpha — Desktop</p>
+      <p class="version">v0.17.4-alpha — Desktop</p>
       <div class="actions">
         <button class="btn" data-type="word">
           <span class="icon">W</span> <span data-i18n="document">Document</span>


### PR DESCRIPTION
x2t does not use fontconfig. It scans a fixed list of directories, so fonts installed per user or exposed by the Flatpak host mounts never reach the editor even though fc-list finds them.

This passes those directories to `x2t -create-allfonts` explicitly on Linux, filtered by existence: the three Flatpak host font mounts, `~/.local/share/fonts` and `~/.fonts`. Windows and macOS are unchanged. Passing directories x2t already scans is safe, it deduplicates them.

Verified on Ubuntu 22.04 with the CI .deb, using a font absent from the system installed in `~/.local/share/fonts`: the generated AllFonts.js grows from 151201 to 151500 bytes and includes the font, it shows up in the font picker with a correct preview, and it renders when applied.

Reported in #29
