### PR TITLE
Fix/pinch zoom scales interface

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -810,6 +810,7 @@ version = "0.1.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",
+ "gtk",
  "image",
  "libc",
  "serde",
@@ -820,6 +821,7 @@ dependencies = [
  "tauri-plugin-printer-v2",
  "tauri-plugin-shell",
  "ureq",
+ "webkit2gtk",
  "zip",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,14 @@ libc = "0.2"
 [target.'cfg(target_os = "windows")'.dependencies]
 tauri-plugin-printer-v2 = "0.2.4"
 
+# Pinned to the version wry links, so PlatformWebview::inner() hands back a
+# WebView of the same type rather than a second, incompatible binding.
+[target.'cfg(target_os = "linux")'.dependencies]
+webkit2gtk = { version = "=2.0.2", features = ["v2_38"] }
+# The WebKitWebView is a GtkWidget; gtk provides the event hook used to claim
+# the touchpad pinch. Same version webkit2gtk resolves, so nothing new is pulled.
+gtk = "0.18"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -497,8 +497,12 @@ fn main() {
                                 if !(0.9..=1.1).contains(&ratio) {
                                     let step = if ratio > 1.0 { 10 } else { -10 };
                                     pending.set(1.0);
+                                    // Position travels with the step so the page can
+                                    // decide whether the gesture is over the document
+                                    // rather than the surrounding chrome.
+                                    let (x, y) = pinch.position();
                                     let _ = eval_window.eval(&format!(
-                                        "window.__eoPinchZoom && window.__eoPinchZoom({step})"
+                                        "window.__eoPinchZoom && window.__eoPinchZoom({step},{x:.1},{y:.1})"
                                     ));
                                 }
                             }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -443,6 +443,38 @@ fn main() {
                 #[cfg(debug_assertions)]
                 window.open_devtools();
 
+                // On Wayland a trackpad pinch arrives as a GDK_TOUCHPAD_PINCH event
+                // that WebKitGTK consumes at the widget level and turns into a scale
+                // of the whole interface. Two things were ruled out by testing: it
+                // does not go through the WebKitWebView zoom-level property, and it
+                // never reaches the DOM, so the JS wheel guard in editor-patches.js
+                // has nothing to cancel. None of the 64 WebKitSettings properties
+                // switch the gesture off. Claim the event before WebKit's own
+                // handler runs, which is the earliest public hook available.
+                #[cfg(target_os = "linux")]
+                {
+                    use gtk::prelude::*;
+                    let pinch_log = temp_dir.clone();
+                    let reported = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+                    if let Err(e) = window.with_webview(move |webview| {
+                        let wv = webview.inner();
+                        log_startup(&pinch_log, "pinch guard installed at GTK level");
+                        wv.connect_event(move |_, event| {
+                            if event.event_type() != gtk::gdk::EventType::TouchpadPinch {
+                                return gtk::glib::Propagation::Proceed;
+                            }
+                            // A single pinch emits a stream of events; record only the
+                            // first so the log stays readable.
+                            if !reported.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                                log_startup(&pinch_log, "touchpad pinch seen at GTK level, event claimed");
+                            }
+                            gtk::glib::Propagation::Stop
+                        });
+                    }) {
+                        log_startup(&temp_dir, &format!("ERROR: pinch guard not installed: {e}"));
+                    }
+                }
+
                 let h = handle.clone();
                 window.on_window_event(move |event| {
                     if let tauri::WindowEvent::CloseRequested { api, .. } = event {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -456,17 +456,51 @@ fn main() {
                     use gtk::prelude::*;
                     let pinch_log = temp_dir.clone();
                     let reported = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+                    let eval_window = window.clone();
                     if let Err(e) = window.with_webview(move |webview| {
                         let wv = webview.inner();
                         log_startup(&pinch_log, "pinch guard installed at GTK level");
+
+                        // gdk 0.18 mis-generates the phase accessor as is_phase() -> bool,
+                        // so gesture boundaries are inferred from the event timestamps
+                        // instead. scale() is relative to the start of the gesture, which
+                        // makes the ratio between consecutive events the useful quantity.
+                        let last_time = std::cell::Cell::new(0u32);
+                        let last_scale = std::cell::Cell::new(1.0f64);
+                        let pending = std::cell::Cell::new(1.0f64);
+
                         wv.connect_event(move |_, event| {
                             if event.event_type() != gtk::gdk::EventType::TouchpadPinch {
                                 return gtk::glib::Propagation::Proceed;
                             }
-                            // A single pinch emits a stream of events; record only the
-                            // first so the log stays readable.
                             if !reported.swap(true, std::sync::atomic::Ordering::Relaxed) {
                                 log_startup(&pinch_log, "touchpad pinch seen at GTK level, event claimed");
+                            }
+
+                            if let Some(pinch) = event.downcast_ref::<gtk::gdk::EventTouchpadPinch>() {
+                                let time = pinch.time();
+                                let scale = pinch.scale();
+                                if time.saturating_sub(last_time.get()) > 300 {
+                                    // Long gap means a new gesture, so start a fresh
+                                    // baseline rather than comparing against the old one.
+                                    pending.set(1.0);
+                                } else if last_scale.get() > 0.0 {
+                                    pending.set(pending.get() * (scale / last_scale.get()));
+                                }
+                                last_scale.set(scale);
+                                last_time.set(time);
+
+                                // Apply in 10% steps so the document zoom moves the way it
+                                // does for Ctrl+= rather than sliding continuously, which
+                                // would re-render the canvas on every event.
+                                let ratio = pending.get();
+                                if !(0.9..=1.1).contains(&ratio) {
+                                    let step = if ratio > 1.0 { 10 } else { -10 };
+                                    pending.set(1.0);
+                                    let _ = eval_window.eval(&format!(
+                                        "window.__eoPinchZoom && window.__eoPinchZoom({step})"
+                                    ));
+                                }
                             }
                             gtk::glib::Propagation::Stop
                         });

--- a/src/editor-patches.js
+++ b/src/editor-patches.js
@@ -41,13 +41,25 @@
       }
     }
 
+    // sdkjs names the document canvases id_viewer and id_viewer_overlay in the
+    // word and slide editors, and ws-canvas* in the spreadsheet. Two callers
+    // need this test from different starting points: the GTK pinch hit test
+    // from an element found by coordinate, the ctrl+wheel guard from an event
+    // target. Keeping the prefixes in one place keeps the two in step.
+    function _eoOverDocumentCanvas(el) {
+      while (el) {
+        var id = el.id || '';
+        if (id.indexOf('id_viewer') === 0 || id.indexOf('ws-canvas') === 0) return true;
+        el = el.parentElement;
+      }
+      return false;
+    }
+
     // The pinch is claimed for the whole window so it can never scale the
     // interface, but it should only zoom when it lands on the document itself,
-    // not the toolbar, rulers, slide thumbnails or notes pane. sdkjs names the
-    // document canvases id_viewer and id_viewer_overlay in the word and slide
-    // editors, and ws-canvas* in the spreadsheet. Coordinates arrive in
-    // top-frame client pixels, so they are rebased onto the editor iframe
-    // before the hit test.
+    // not the toolbar, rulers, slide thumbnails or notes pane. Coordinates
+    // arrive in top-frame client pixels, so they are rebased onto the editor
+    // iframe before the hit test.
     function _eoPinchOverDocument(x, y) {
       var ew = window.AscDesktopEditor && window.AscDesktopEditor._editorWindow;
       if (!ew || !ew.document || typeof x !== 'number' || typeof y !== 'number') return false;
@@ -59,13 +71,7 @@
         fx = x - r.left;
         fy = y - r.top;
       }
-      var el = ew.document.elementFromPoint(fx, fy);
-      while (el) {
-        var id = el.id || '';
-        if (id.indexOf('id_viewer') === 0 || id.indexOf('ws-canvas') === 0) return true;
-        el = el.parentElement;
-      }
-      return false;
+      return _eoOverDocumentCanvas(ew.document.elementFromPoint(fx, fy));
     }
 
     // Called from the GTK pinch handler in main.rs, which runs eval against the
@@ -127,7 +133,6 @@
         try { where = doc.location ? doc.location.href : '(no location)'; } catch(e) {}
         window._eoLog('[EO] pinch guard attached: ' + window._eoSafeSource(where));
 
-        var accum = 0;
         var sawEvent = false;
         doc.addEventListener('wheel', function(e) {
           if (!(e.ctrlKey || e.metaKey)) return;
@@ -135,12 +140,7 @@
           // cancels the default, so the guard only needs to suppress the
           // webview page zoom when the event lands on the surrounding chrome
           // (toolbar, rulers, pasteboard).
-          var el = e.target;
-          while (el) {
-            var id = el.id || '';
-            if (id.indexOf('id_viewer') === 0 || id.indexOf('ws-canvas') === 0) return;
-            el = el.parentElement;
-          }
+          if (_eoOverDocumentCanvas(e.target)) return;
           if (!sawEvent) {
             sawEvent = true;
             window._eoLog('[EO] pinch: ctrl+wheel reached the DOM, deltaY=' + e.deltaY);

--- a/src/editor-patches.js
+++ b/src/editor-patches.js
@@ -41,7 +41,77 @@
       }
     }
 
+    // Ctrl+wheel would otherwise trigger the webview's own page zoom, which
+    // scales the toolbar and panels along with the document. The official
+    // desktop app does not have this problem because its CEF shell never wires
+    // zoom to the gesture; suppressing it is the shell's job, and for this
+    // wrapper that means doing it here. sdkjs only cancels ctrl+wheel over its
+    // own canvases, so anything over the pasteboard, rulers or toolbar escapes.
+    //
+    // This covers mouse ctrl+wheel everywhere, and pinch on WKWebView, which
+    // reports it as gesture events. It does not cover trackpad pinch on
+    // Wayland: that arrives as a GDK_TOUCHPAD_PINCH event which WebKitGTK
+    // consumes before the DOM sees anything, so it is blocked in main.rs.
+    function installPinchZoomGuard(win) {
+      try {
+        if (!win || !win.document) return;
+        // Keyed on the document, not the window. The editor iframe is injected
+        // while it is still about:blank and then navigates, which replaces the
+        // document but keeps the window. A window-keyed flag left the listener
+        // on the discarded about:blank document and blocked reinstallation on
+        // the real editor document, so the guard was never live.
+        var doc = win.document;
+        if (doc.__eoPinchZoomGuard) return;
+        doc.__eoPinchZoomGuard = true;
+
+        var where = '';
+        try { where = doc.location ? doc.location.href : '(no location)'; } catch(e) {}
+        window._eoLog('[EO] pinch guard attached: ' + window._eoSafeSource(where));
+
+        var accum = 0;
+        var sawEvent = false;
+        doc.addEventListener('wheel', function(e) {
+          if (!(e.ctrlKey || e.metaKey)) return;
+          // Whether a trackpad pinch reaches the DOM at all is the open question
+          // on Wayland. Record the first one so the log answers it directly.
+          if (!sawEvent) {
+            sawEvent = true;
+            window._eoLog('[EO] pinch: ctrl+wheel reached the DOM, deltaY=' + e.deltaY);
+          }
+          e.preventDefault();
+
+          var api = win.Asc && win.Asc.editor;
+          if (!api || !api.WordControl || typeof api.zoom !== 'function') return;
+
+          accum += e.deltaY;
+          if (Math.abs(accum) < 40) return;
+          var step = accum < 0 ? 10 : -10;
+          accum = 0;
+
+          var current = api.WordControl.m_nZoomValue || 100;
+          api.zoom(Math.max(25, Math.min(500, current + step)));
+        }, { capture: true, passive: false });
+
+        // WKWebView reports pinch as gesture events rather than ctrl+wheel.
+        // gesturechange fires continuously for the duration of a pinch, so the
+        // log is one-shot; logging each event would fill the file.
+        var sawGesture = false;
+        ['gesturestart', 'gesturechange', 'gestureend'].forEach(function(type) {
+          doc.addEventListener(type, function(e) {
+            if (!sawGesture) {
+              sawGesture = true;
+              window._eoLog('[EO] pinch: gesture events reached the DOM, first was ' + type);
+            }
+            if (e.preventDefault) e.preventDefault();
+          }, { capture: true, passive: false });
+        });
+      } catch(e) {
+        window._eoLog('[EO] pinch-zoom guard install failed: ' + (e.message || e));
+      }
+    }
+
     function injectBridgeDeep(win) {
+      installPinchZoomGuard(win);
       try {
         var hasADE = false;
         try { hasADE = !!win.AscDesktopEditor; } catch(e) {}
@@ -663,6 +733,10 @@
       }
       return el;
     };
+
+    // Guard the outer document too, so pinch over the start screen (before any
+    // editor iframe exists) cannot zoom the shell.
+    installPinchZoomGuard(window);
 
     window._openEditor = openEditor;
     async function openEditor(docType) {

--- a/src/editor-patches.js
+++ b/src/editor-patches.js
@@ -131,24 +131,21 @@
         var sawEvent = false;
         doc.addEventListener('wheel', function(e) {
           if (!(e.ctrlKey || e.metaKey)) return;
-          // Whether a trackpad pinch reaches the DOM at all is the open question
-          // on Wayland. Record the first one so the log answers it directly.
+          // Over the editor canvases sdkjs handles ctrl+wheel zoom itself and
+          // cancels the default, so the guard only needs to suppress the
+          // webview page zoom when the event lands on the surrounding chrome
+          // (toolbar, rulers, pasteboard).
+          var el = e.target;
+          while (el) {
+            var id = el.id || '';
+            if (id.indexOf('id_viewer') === 0 || id.indexOf('ws-canvas') === 0) return;
+            el = el.parentElement;
+          }
           if (!sawEvent) {
             sawEvent = true;
             window._eoLog('[EO] pinch: ctrl+wheel reached the DOM, deltaY=' + e.deltaY);
           }
           e.preventDefault();
-
-          var api = win.Asc && win.Asc.editor;
-          if (!api || !api.WordControl || typeof api.zoom !== 'function') return;
-
-          accum += e.deltaY;
-          if (Math.abs(accum) < 40) return;
-          var step = accum < 0 ? 10 : -10;
-          accum = 0;
-
-          var current = api.WordControl.m_nZoomValue || 100;
-          api.zoom(Math.max(25, Math.min(500, current + step)));
         }, { capture: true, passive: false });
 
         // WKWebView reports pinch as gesture events rather than ctrl+wheel.

--- a/src/editor-patches.js
+++ b/src/editor-patches.js
@@ -41,22 +41,49 @@
       }
     }
 
-    // Ctrl+wheel would otherwise trigger the webview's own page zoom, which
-    // scales the toolbar and panels along with the document. The official
-    // desktop app does not have this problem because its CEF shell never wires
-    // zoom to the gesture; suppressing it is the shell's job, and for this
-    // wrapper that means doing it here. sdkjs only cancels ctrl+wheel over its
-    // own canvases, so anything over the pasteboard, rulers or toolbar escapes.
-    //
-    // This covers mouse ctrl+wheel everywhere, and pinch on WKWebView, which
-    // reports it as gesture events. It does not cover trackpad pinch on
-    // Wayland: that arrives as a GDK_TOUCHPAD_PINCH event which WebKitGTK
-    // consumes before the DOM sees anything, so it is blocked in main.rs.
+    // The pinch is claimed for the whole window so it can never scale the
+    // interface, but it should only zoom when it lands on the document itself,
+    // not the toolbar, rulers, slide thumbnails or notes pane. sdkjs names the
+    // document canvases id_viewer and id_viewer_overlay in the word and slide
+    // editors, and ws-canvas* in the spreadsheet. Coordinates arrive in
+    // top-frame client pixels, so they are rebased onto the editor iframe
+    // before the hit test.
+    function _eoPinchOverDocument(x, y) {
+      var ew = window.AscDesktopEditor && window.AscDesktopEditor._editorWindow;
+      if (!ew || !ew.document || typeof x !== 'number' || typeof y !== 'number') return false;
+      var fx = x, fy = y;
+      var frame = ew.frameElement;
+      if (frame && frame.getBoundingClientRect) {
+        var r = frame.getBoundingClientRect();
+        if (x < r.left || x >= r.right || y < r.top || y >= r.bottom) return false;
+        fx = x - r.left;
+        fy = y - r.top;
+      }
+      var el = ew.document.elementFromPoint(fx, fy);
+      while (el) {
+        var id = el.id || '';
+        if (id.indexOf('id_viewer') === 0 || id.indexOf('ws-canvas') === 0) return true;
+        el = el.parentElement;
+      }
+      return false;
+    }
+
     // Called from the GTK pinch handler in main.rs, which runs eval against the
     // top frame. The editor api lives in the iframe, so the lookup goes through
-    // the bridge's editor window handle. step is a zoom percentage delta.
-    window.__eoPinchZoom = function(step) {
+    // the bridge's editor window handle. step is a zoom percentage delta, and
+    // x/y are where the gesture is, in top-frame client pixels.
+    //
+    // The step is deliberately a relative nudge rather than an absolute target
+    // derived from the gesture's total scale. GDK reports scale relative to the
+    // start of a gesture, and gesture boundaries have to be guessed from a gap
+    // between event timestamps because gdk 0.18 mis-generates the phase
+    // accessor as is_phase() -> bool, collapsing begin, update, end and cancel
+    // into one value. A missed boundary makes an absolute target snap the
+    // document back to the zoom it had before the previous gesture, while a
+    // relative nudge just costs one step.
+    window.__eoPinchZoom = function(step, x, y) {
       try {
+        if (!_eoPinchOverDocument(x, y)) return;
         var ew = window.AscDesktopEditor && window.AscDesktopEditor._editorWindow;
         var api = ew && ew.Asc && ew.Asc.editor;
         if (!api) return;
@@ -73,6 +100,17 @@
       }
     };
 
+    // Ctrl+wheel would otherwise trigger the webview's own page zoom, which
+    // scales the toolbar and panels along with the document. The official
+    // desktop app does not have this problem because its CEF shell never wires
+    // zoom to the gesture; suppressing it is the shell's job, and for this
+    // wrapper that means doing it here. sdkjs only cancels ctrl+wheel over its
+    // own canvases, so anything over the pasteboard, rulers or toolbar escapes.
+    //
+    // This covers mouse ctrl+wheel everywhere, and pinch on WKWebView, which
+    // reports it as gesture events. It does not cover trackpad pinch on
+    // Wayland: that arrives as a GDK_TOUCHPAD_PINCH event which WebKitGTK
+    // consumes before the DOM sees anything, so it is handled in main.rs.
     function installPinchZoomGuard(win) {
       try {
         if (!win || !win.document) return;

--- a/src/editor-patches.js
+++ b/src/editor-patches.js
@@ -52,6 +52,27 @@
     // reports it as gesture events. It does not cover trackpad pinch on
     // Wayland: that arrives as a GDK_TOUCHPAD_PINCH event which WebKitGTK
     // consumes before the DOM sees anything, so it is blocked in main.rs.
+    // Called from the GTK pinch handler in main.rs, which runs eval against the
+    // top frame. The editor api lives in the iframe, so the lookup goes through
+    // the bridge's editor window handle. step is a zoom percentage delta.
+    window.__eoPinchZoom = function(step) {
+      try {
+        var ew = window.AscDesktopEditor && window.AscDesktopEditor._editorWindow;
+        var api = ew && ew.Asc && ew.Asc.editor;
+        if (!api) return;
+        if (api.WordControl && typeof api.zoom === 'function') {
+          var current = api.WordControl.m_nZoomValue || 100;
+          api.zoom(Math.max(25, Math.min(500, current + step)));
+        } else if (typeof api.asc_getZoom === 'function' && typeof api.asc_setZoom === 'function') {
+          // Spreadsheets have no WordControl and take a factor, not a percent.
+          var factor = api.asc_getZoom() || 1;
+          api.asc_setZoom(Math.max(0.25, Math.min(5, factor + step / 100)));
+        }
+      } catch(e) {
+        window._eoLog('[EO] pinch zoom forward failed: ' + (e.message || e));
+      }
+    };
+
     function installPinchZoomGuard(win) {
       try {
         if (!win || !win.document) return;


### PR DESCRIPTION
## Upfront disclosure: I nailed this down using Claude Opus 5. If you want to keep agent code out of your project, that's understandable and then just treat this as research results.
 
### Summary

On Linux, a trackpad pinch zooms the whole UI. As we discussed in the issue thread, we want to grab that input before it gets interpreted as a zoom on the whole page. This PR fixes #40 

### Change

 Three commits fixes it on my test machine. First, claim the GDK_TOUCHPAD_PINCH event on the widget before WebKit's handler runs, and forward it to the editor's zoom. Then, restrict zooming to the document area (id_viewer* in word and slide, ws-canvas* in cell). The event is still claimed everywhere, so a pinch over the toolbar does nothing rather than passing through to WebKit.

This also fixes a reinstall bug in the JS guard. It was keyed on the window, but the editor iframe is injected while still about:blank and then navigates, so the listener stayed on the discarded document and never reattached. It is now keyed on the document.

The GTK hook is #[cfg(target_os = "linux")] and cannot affect Windows or macOS builds. It adds gtk and webkit2gtk as Linux-only dependencies, both already in the lockfile via wry and pinned to the versions wry resolves.

### Testing

Zooming confirmed on PPTX, DOCX and XLSX. Pinching over the toolbar, slide thumbnails and notes pane does nothing. 

I'm on Fedora 44, Wayland, webkit2gtk 2.52.5.
