### PR TITLE
build: track frontend files so tauri dev re-embeds them

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,23 @@
 fn main() {
+    // tauri_build tracks tauri.conf.json, capabilities and the bundled
+    // resources, but not frontendDist. The frontend is embedded into the binary
+    // by generate_context! at compile time, so without these lines cargo has no
+    // dependency edge to the wrapper's own JS: editing it does not mark the
+    // crate dirty, and `tauri dev` keeps serving whatever was embedded the last
+    // time something else forced a rebuild.
+    //
+    // Only the wrapper's own files are listed. frontendDist points at ../src,
+    // which also contains the sdkjs and web-apps submodules; walking those would
+    // add tens of thousands of paths to every build's dependency check.
+    for file in [
+        "index.html",
+        "bridge.js",
+        "button-hint-patch.js",
+        "font-patches.js",
+        "editor-patches.js",
+    ] {
+        println!("cargo:rerun-if-changed=../src/{file}");
+    }
+
     tauri_build::build()
 }


### PR DESCRIPTION
frontendDist is embedded into the binary by generate_context! at compile time, but the build script's rerun-if-changed output does not mention it. From target/debug/build/euro-office-lite-*/output the tracked paths are tauri.conf.json, capabilities, templates, and the binaries and editors resources. target/debug/euro-office-lite.d lists only .rs files.

The effect showed up as a frontend change that appeared to do nothing for three weeks. The codegen asset cache held 23188 entries dated 7 August and no entry for the edited file until a rebuild was forced on 30 August, so the running binary had been serving a frontend snapshot from before the edit.

I could not reduce this to a minimal before and after demonstration. On a tree where the build script regenerates gen/schemas on each run, the crate recompiles on every cargo build regardless, which masks the difference. This change rests on the missing rerun-if-changed entries and the observed staleness, not on a controlled reproduction.

Only the wrapper's own five files are listed. frontendDist also contains the sdkjs and web-apps submodules; walking those would add tens of thousands of paths to every dependency check.